### PR TITLE
UartDataHandler : UARTTB_PARITY_NONE issue

### DIFF
--- a/src/UartRx.vhd
+++ b/src/UartRx.vhd
@@ -349,7 +349,11 @@ begin
       when RX_STOP =>
         ErrorMode(UARTTB_PARITY_INDEX) := CalcParity(RxData, ParityMode) ?/= RxParity ;
         ErrorMode(UARTTB_STOP_INDEX)   := not to_01(iSerialDataIn) ;
-        ErrorMode(UARTTB_BREAK_INDEX)  := not (iSerialDataIn or RxParity or (or RxData)) ;
+        if ParityMode /= UARTTB_PARITY_NONE then
+			    ErrorMode(UARTTB_BREAK_INDEX)  := not (iSerialDataIn or RxParity or (or RxData)) ;
+		    else
+			    ErrorMode(UARTTB_BREAK_INDEX)  := not (iSerialDataIn or (or RxData)) ;
+		    end if;
         if ErrorMode(UARTTB_BREAK_INDEX) = '1' then 
           Log(ModelID, "UartRx  Break Detected", INFO) ;
         end if ; 


### PR DESCRIPTION
When UARTTB_PARITY_NONE is configured the RxParity variable will  be unassigned and make ErrorMode(UARTTB_BREAK_INDEX) to be unknown. 