### PR TITLE
remove references to build_one.pro in RunDemoTests.pro

### DIFF
--- a/RunDemoTests.pro
+++ b/RunDemoTests.pro
@@ -42,7 +42,7 @@ TestSuite Uart
 library   osvvm_TbUart
 
 if {$::osvvm::ToolNameVersion ne "XSIM-2023.2"}  {
-  include ./testbench/build_one.pro
+  include ./testbench/build.pro
 } else {
-  include ./testbench_xilinx/build_one.pro
+  include ./testbench_xilinx/build.pro
 }


### PR DESCRIPTION
The file "build_one.pro" only exists in the Xilinx specific testbench directory and appears to be a remnant of recent development. Remove it so the recommended "RunDemoTests.pro" runs without error.