### PR TITLE
Include correct .pro file in RunDemoTests.pro

### DIFF
--- a/RunDemoTests.pro
+++ b/RunDemoTests.pro
@@ -42,7 +42,7 @@ TestSuite Uart
 library   osvvm_TbUart
 
 if {$::osvvm::ToolNameVersion ne "XSIM-2023.2"}  {
-  include ./testbench/build_one.pro
+  include ./testbench/build.pro
 } else {
   include ./testbench_xilinx/build_one.pro
 }


### PR DESCRIPTION
In ``RunDemoTests.pro``, when the simulator is not XSIM-2023.2, a ``.pro`` file which doesn't exist is included. This PR fixes that issue by including the correct file