### PR TITLE
Initialize BurstFifo to prevent scoreboard errors

### DIFF
--- a/UART.pro
+++ b/UART.pro
@@ -7,7 +7,7 @@
 #
 #
 #  Description:
-#        Script to compile the OSVVM UART models  
+#        Script to compile the OSVVM UART models
 #
 #  Developed for:
 #        SynthWorks Design Inc.
@@ -23,15 +23,15 @@
 #
 #
 #  This file is part of OSVVM.
-#  
-#  Copyright (c) 2019 - 2020 by SynthWorks Design Inc.  
-#  
+#
+#  Copyright (c) 2019 - 2020 by SynthWorks Design Inc.
+#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#  
+#
 #      https://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,7 +42,7 @@ library osvvm_uart
 if {$::osvvm::ToolNameVersion ne "XSIM-2023.2"}  {
   analyze ./src/UartTbPkg.vhd
 } else {
-  analyze ./src/UartTbPkg_xilinx.vhd
+  analyze ./src/deprecated/UartTbPkg_xilinx.vhd
 }
 
 if {$::osvvm::ToolSupportsGenericPackages}  {
@@ -60,4 +60,4 @@ if {$::osvvm::ToolNameVersion ne "XSIM-2023.2"}  {
 } else {
   analyze ./src/deprecated/UartTx_xilinx.vhd
   analyze ./src/deprecated/UartRx_xilinx.vhd
-}  
+}

--- a/src/UartRx.vhd
+++ b/src/UartRx.vhd
@@ -152,7 +152,10 @@ begin
     ParityMode    <= CheckParityMode (ModelID, DEFAULT_PARITY_MODE,   FALSE) ; 
     NumStopBits   <= CheckNumStopBits(ModelID, DEFAULT_NUM_STOP_BITS, FALSE) ; 
     NumDataBits   <= CheckNumDataBits(ModelID, DEFAULT_NUM_DATA_BITS, FALSE) ; 
-    Baud          <= CheckBaud(ModelID, DEFAULT_BAUD, FALSE) ;  
+    Baud          <= CheckBaud(ModelID, DEFAULT_BAUD, FALSE) ;
+    -- Initialize BurstFifo even though it is not used, to prevent weird errors
+    TransRec.BurstFifo <= NewID("RxBurstFifo", ModelID, Search => PRIVATE_NAME) ;
+    wait for 0 ns ;  -- Allow TransRec.BurstFifo to update.
 
     TransactionDispatcherLoop : loop 
       WaitForTransaction(

--- a/src/UartTx.vhd
+++ b/src/UartTx.vhd
@@ -130,7 +130,10 @@ begin
     ParityMode    <= CheckParityMode (ModelID, DEFAULT_PARITY_MODE,   FALSE) ; 
     NumStopBits   <= CheckNumStopBits(ModelID, DEFAULT_NUM_STOP_BITS, FALSE) ; 
     NumDataBits   <= CheckNumDataBits(ModelID, DEFAULT_NUM_DATA_BITS, FALSE) ; 
-    Baud          <= CheckBaud(ModelID, DEFAULT_BAUD, FALSE) ;  
+    Baud          <= CheckBaud(ModelID, DEFAULT_BAUD, FALSE) ;
+    -- Initialize BurstFifo even though it is not used, to prevent weird errors
+    TransRec.BurstFifo <= NewID("TxBurstFifo", ModelID, Search => PRIVATE_NAME) ;
+    wait for 0 ns ;  -- Allow TransRec.BurstFifo to update.
 
     TransactionDispatcherLoop : loop 
       WaitForTransaction(


### PR DESCRIPTION
I ran into a scoreboard error when trying to use `CheckBurstVector`, but then I realized that was because burst vectors are not supported by the UART VC. This PR makes the error message you get a bit clearer by initializing BurstFifo even though burst vectors are not supported.
This prevents weird errors that could catch out beginners. Now you get the correct 'Unimplemented' error instead of a scoreboard index out of range.